### PR TITLE
Upgrade to latest can+done-autorender

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -117,9 +117,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.2.tgz",
-      "integrity": "sha512-UNTmQ5cSLDeBGBl+s7JeowkqIHgmFAGBnLDdIzFmUNSuS5JF0XBcN59jsh/vJO/YjfsBqMxhMjoFGmNExmf0FA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+      "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
       "dev": true
     },
     "@babel/template": {
@@ -134,16 +134,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.2.tgz",
-      "integrity": "sha512-E5Bn9FSwHpSkUhthw/XEuvFZxIgrqb9M8cX8j5EUQtrUG5DQUy6bFyl7G7iQ1D1Czudor+xkmp81JbLVVM0Sjg==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.2.2",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.2",
+        "@babel/parser": "^7.2.3",
         "@babel/types": "^7.2.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -151,9 +151,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -199,9 +199,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.17.tgz",
-      "integrity": "sha512-umSCRkjWH70uNzFiOof5yxCqrMXIBJ9UJJUzbEsmtWt8apURQh06pylGMqnhdjHGJSeoBrhzk+mibu6NgL1oBA==",
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
       "dev": true
     },
     "@types/socket.io": {
@@ -266,10 +266,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -512,7 +511,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -1359,9 +1358,9 @@
       "dev": true
     },
     "can": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/can/-/can-5.21.0.tgz",
-      "integrity": "sha512-YKRtSnGAgHHVeA7pIKeya83KQq87ReNEQXzYdqcIdz7PS02SLYIl04UqLPrj3kP0ooO3UIle79Rj3iCn+/K5Rg==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/can/-/can-5.21.2.tgz",
+      "integrity": "sha512-33aJCeNpUyuJSSJaF7UhGlwELmhWk0zhhL8qnEwcrnel1T6kXfm532aQpO7whsbuvN79gW2NKGcB7B1P0JjzFQ==",
       "requires": {
         "can-ajax": "2.1.1",
         "can-assign": "1.3.1",
@@ -1370,7 +1369,7 @@
         "can-bind": "1.3.0",
         "can-child-nodes": "1.2.0",
         "can-cid": "1.3.0",
-        "can-component": "4.4.10",
+        "can-component": "4.4.11",
         "can-compute": "4.1.0",
         "can-connect": "3.0.5",
         "can-connect-feathers": "5.0.0",
@@ -1381,7 +1380,7 @@
         "can-control": "4.4.1",
         "can-data-types": "1.2.0",
         "can-debug": "2.0.5",
-        "can-define": "2.7.4",
+        "can-define": "2.7.5",
         "can-define-backup": "2.1.1",
         "can-define-lazy-value": "1.1.0",
         "can-define-stream": "1.1.0",
@@ -1433,7 +1432,7 @@
         "can-simple-dom": "1.6.1",
         "can-simple-map": "4.3.0",
         "can-simple-observable": "2.4.1",
-        "can-stache": "4.17.1",
+        "can-stache": "4.17.3",
         "can-stache-bindings": "4.8.0",
         "can-stache-converters": "4.2.5",
         "can-stache-key": "1.4.0",
@@ -1461,54 +1460,10 @@
         "steal-stache": "4.1.2"
       },
       "dependencies": {
-        "can-globals": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/can-globals/-/can-globals-1.2.1.tgz",
-          "integrity": "sha512-p9EPyWD7wZ2xIqtAXGCPxnhFPFLJL3qsoO5V60EDscc62dcS1ctr1F8y5lxuYhREj9HVIpNlvVwmU1vY6jocuw==",
-          "requires": {
-            "can-namespace": "^1.0.0",
-            "can-reflect": "^1.2.6",
-            "can-symbol": "^1.0.0"
-          }
-        },
-        "can-observation": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/can-observation/-/can-observation-4.1.2.tgz",
-          "integrity": "sha512-4bd+uqqq9B5eYIuMKg7wbsdXZFcXLZjLUUrybzM8RfLw2XaM9PvLSGqokBW31OmIYyk0USqOrR8nZqpjmlGAng==",
-          "requires": {
-            "can-event-queue": "^1.0.0",
-            "can-key-tree": "^1.0.0",
-            "can-log": "^1.0.0",
-            "can-namespace": "1.0.0",
-            "can-observation-recorder": "^1.0.0",
-            "can-queues": "^1.0.0",
-            "can-reflect": "^1.7.0",
-            "can-symbol": "^1.4.2"
-          }
-        },
-        "can-reflect": {
-          "version": "1.17.9",
-          "resolved": "https://registry.npmjs.org/can-reflect/-/can-reflect-1.17.9.tgz",
-          "integrity": "sha512-BH8rKaQKK8Rj/1xnyKgj1zITLk3AVyDWZ9nR+aELDP19I0rbMS6w2Yeeo/yisWZUbsKS4moZRGDQi58Oo01Z4A==",
-          "requires": {
-            "can-namespace": "^1.0.0",
-            "can-symbol": "^1.6.4"
-          }
-        },
-        "can-simple-dom": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/can-simple-dom/-/can-simple-dom-1.6.1.tgz",
-          "integrity": "sha512-ObbVwtLctsSbYJGlLDUwTXfQXklHooZ4Rv0znQ3I1XAVaFDePcmhJ8gjkJE20733gagX4UL0xZS8ks5jIHATjg==",
-          "requires": {
-            "he": "^1.1.0",
-            "micro-location": "^0.1.4",
-            "simple-html-tokenizer": "^0.2.1"
-          }
-        },
         "can-stache": {
-          "version": "4.17.1",
-          "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.17.1.tgz",
-          "integrity": "sha512-x18f9VvIQb16inGytLg8kdkcDxKGaIq2fNVT110fv9PcXdrUndjQXBRcaDR9YQnFIedgKIY0Qqx3QDHNdI/+zA==",
+          "version": "4.17.3",
+          "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.17.3.tgz",
+          "integrity": "sha512-ZY0/tZcSvLDRiZUsMoyz6vS+h/zAB8Ws4VgH/3XTSqY5TEC4PPmAhbeZHgGKwheXNpZn7Rf4hKfuNsoO3Hgs4g==",
           "requires": {
             "can-assign": "^1.1.1",
             "can-attribute-encoder": "^1.0.0",
@@ -1538,42 +1493,6 @@
             "can-view-parser": "^4.0.0",
             "can-view-scope": "^4.12.0",
             "can-view-target": "^4.0.0"
-          }
-        },
-        "can-symbol": {
-          "version": "1.6.4",
-          "resolved": "https://registry.npmjs.org/can-symbol/-/can-symbol-1.6.4.tgz",
-          "integrity": "sha512-fHRzqcjqZLTvdYoEzdEI/oXG4B7u21+TsYdSTOIB+I8ANe3khqLIhH5cpEa91NMFLDZK/d6TVoXIxevAkqBMDQ==",
-          "requires": {
-            "can-namespace": "^1.0.0"
-          }
-        },
-        "can-vdom": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/can-vdom/-/can-vdom-4.4.1.tgz",
-          "integrity": "sha512-CbyHERAYPQ8nIN0mSM4X32vWmNaIt3MLCpb6d15OAwu23+0I/KLGB7cv2lx2THZAJ+1vy07Ry6lILYxSaEawTw==",
-          "requires": {
-            "can-assign": "^1.0.0",
-            "can-globals": "^1.0.0",
-            "can-log": "^1.0.0",
-            "can-simple-dom": "^1.6.1",
-            "can-view-parser": "^4.0.0"
-          }
-        },
-        "can-view-callbacks": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/can-view-callbacks/-/can-view-callbacks-4.3.3.tgz",
-          "integrity": "sha512-p63HX3803px30vWrXgog1mRaa3zwABstfb63oSl6DAZ9t/Drc0bCS3FtKDdMKSwY8vLrC8Uytg9hiwQdeKGGKg==",
-          "requires": {
-            "can-dom-mutate": "^1.0.0",
-            "can-fragment": "^1.0.0",
-            "can-globals": "^1.0.0",
-            "can-log": "^1.0.0",
-            "can-namespace": "1.0.0",
-            "can-observation-recorder": "^1.0.0",
-            "can-reflect": "^1.16.7",
-            "can-symbol": "^1.6.1",
-            "can-view-nodelist": "^4.0.0"
           }
         }
       }
@@ -1658,9 +1577,9 @@
       }
     },
     "can-component": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/can-component/-/can-component-4.4.10.tgz",
-      "integrity": "sha512-WH8L9umF14qleoYMC4+FvYzspaNomulEzjICvHhQsJ+srcIjm4bhWMF+xGDOGVjG0RkSS+jlb8q51URX9aQj+A==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/can-component/-/can-component-4.4.11.tgz",
+      "integrity": "sha512-Vv7RJmoB4moj4wjddsbSp+Cz+yg+DVbbH3tJCtUFEw35We2DfQTcF/SxXq013ms3Jj9eb3Iie1U7UcWT+MQBQQ==",
       "requires": {
         "can-assign": "^1.1.1",
         "can-bind": "<2.0.0",
@@ -1847,9 +1766,9 @@
       }
     },
     "can-define": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/can-define/-/can-define-2.7.4.tgz",
-      "integrity": "sha512-ne8IqpSXlZFnSTtPdybzn3j3/p3+n+svUBcrkDRouweXj5nXdi7/LvRjBIWpCvliNePHbX/ws0BdPe9324JFqw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/can-define/-/can-define-2.7.5.tgz",
+      "integrity": "sha512-4P54/SIH8hwB3OLP6kAAjWMRNZl8zOdYMxE7wnbewItVXSnVP0f/ZxWohdN3he0No97BNNOb6jhdV4YtAU5qcA==",
       "requires": {
         "can-assign": "^1.1.1",
         "can-construct": "^3.5.2",
@@ -2064,9 +1983,9 @@
       }
     },
     "can-globals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/can-globals/-/can-globals-1.2.0.tgz",
-      "integrity": "sha512-FTzANPGBE6k3sJrxzx8NQP28LaFto0AEp/aMVwDGKwOs6lHN+RvRH4sBijAxVMK+4WzALlSVNPSqUyp0xyEk0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/can-globals/-/can-globals-1.2.1.tgz",
+      "integrity": "sha512-p9EPyWD7wZ2xIqtAXGCPxnhFPFLJL3qsoO5V60EDscc62dcS1ctr1F8y5lxuYhREj9HVIpNlvVwmU1vY6jocuw==",
       "requires": {
         "can-namespace": "^1.0.0",
         "can-reflect": "^1.2.6",
@@ -2248,9 +2167,9 @@
       }
     },
     "can-observation": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/can-observation/-/can-observation-4.1.1.tgz",
-      "integrity": "sha512-tG0hSJxQ5LLQokxVacpWLh4ZFHItCXKtABo6mY3QJ9dg4qLFoB7Dfj3s4gW3SZdmxIpN4w3l6PaohFQc2k6BHg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/can-observation/-/can-observation-4.1.2.tgz",
+      "integrity": "sha512-4bd+uqqq9B5eYIuMKg7wbsdXZFcXLZjLUUrybzM8RfLw2XaM9PvLSGqokBW31OmIYyk0USqOrR8nZqpjmlGAng==",
       "requires": {
         "can-event-queue": "^1.0.0",
         "can-key-tree": "^1.0.0",
@@ -2338,12 +2257,12 @@
       }
     },
     "can-reflect": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/can-reflect/-/can-reflect-1.17.7.tgz",
-      "integrity": "sha512-2UB2CXXgEC9hXU3QEjlJhgKz0/DvU+FJLs/ipF7Nf9kha8r9A9vOAQmk+GRQQOCK8oUx5OR3g80aKcL4SpHz/A==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/can-reflect/-/can-reflect-1.17.9.tgz",
+      "integrity": "sha512-BH8rKaQKK8Rj/1xnyKgj1zITLk3AVyDWZ9nR+aELDP19I0rbMS6w2Yeeo/yisWZUbsKS4moZRGDQi58Oo01Z4A==",
       "requires": {
         "can-namespace": "^1.0.0",
-        "can-symbol": "^1.3.0"
+        "can-symbol": "^1.6.4"
       }
     },
     "can-reflect-dependencies": {
@@ -2457,9 +2376,9 @@
       }
     },
     "can-simple-dom": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/can-simple-dom/-/can-simple-dom-1.4.2.tgz",
-      "integrity": "sha512-ywC9tBwn30jl6C4EnQZe0msGJ+XiasAcZNlOtVKUp9qB3JetsRCVAV+XmUR9AwCa5iT1LFDFK97IW8uo7XiIoA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/can-simple-dom/-/can-simple-dom-1.6.1.tgz",
+      "integrity": "sha512-ObbVwtLctsSbYJGlLDUwTXfQXklHooZ4Rv0znQ3I1XAVaFDePcmhJ8gjkJE20733gagX4UL0xZS8ks5jIHATjg==",
       "requires": {
         "he": "^1.1.0",
         "micro-location": "^0.1.4",
@@ -2517,9 +2436,9 @@
       }
     },
     "can-stache": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.16.0.tgz",
-      "integrity": "sha512-1cwv6kIUiFQDK+XUSPtJv7sRy6DgSLMjy3xiRJicmG72mIAqWRBtLOe+o5R+CHCfLWmB9XuNzd2r2T1JM9pf+A==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.17.2.tgz",
+      "integrity": "sha512-ewY+KaD/jg1WdzqIdvsb/7Dw9VVAECk1gH92k48lgpkUrBlQp1KeaQKsD6/Q4cC44eoM+2w3Ck9s8Z5yHCl+Pw==",
       "requires": {
         "can-assign": "^1.1.1",
         "can-attribute-encoder": "^1.0.0",
@@ -2684,9 +2603,9 @@
       }
     },
     "can-symbol": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/can-symbol/-/can-symbol-1.6.3.tgz",
-      "integrity": "sha512-q+oHN5MyHxahTCvYonXhH7AaRlkdhsSlmWtZN0tvlBIQ/uHoDQtZypp+7nZD2enkH/5Qd2l3dXaHuzFeUfzQfQ==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/can-symbol/-/can-symbol-1.6.4.tgz",
+      "integrity": "sha512-fHRzqcjqZLTvdYoEzdEI/oXG4B7u21+TsYdSTOIB+I8ANe3khqLIhH5cpEa91NMFLDZK/d6TVoXIxevAkqBMDQ==",
       "requires": {
         "can-namespace": "^1.0.0"
       }
@@ -2818,14 +2737,14 @@
       }
     },
     "can-vdom": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/can-vdom/-/can-vdom-4.4.0.tgz",
-      "integrity": "sha512-5ov1OjyTFIQ8SsWy2ymvhfhlngbwzNT+TDJW5KbNg/oQ5o3IVVbOmtUwDbwJzmR2jtcgRP4rxgCBt07i/Z30uw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/can-vdom/-/can-vdom-4.4.1.tgz",
+      "integrity": "sha512-CbyHERAYPQ8nIN0mSM4X32vWmNaIt3MLCpb6d15OAwu23+0I/KLGB7cv2lx2THZAJ+1vy07Ry6lILYxSaEawTw==",
       "requires": {
         "can-assign": "^1.0.0",
         "can-globals": "^1.0.0",
         "can-log": "^1.0.0",
-        "can-simple-dom": "^1.1.0",
+        "can-simple-dom": "^1.6.1",
         "can-view-parser": "^4.0.0"
       }
     },
@@ -2843,9 +2762,9 @@
       }
     },
     "can-view-callbacks": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/can-view-callbacks/-/can-view-callbacks-4.3.2.tgz",
-      "integrity": "sha512-oJ4Nr7ndVge4Sx5A1vTglCI/zi8cSbtocQ8dCkdDREisKOpln6cCKoQNz8+PN1mpenYMXpRtDeyb7/HOteBZkQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/can-view-callbacks/-/can-view-callbacks-4.3.3.tgz",
+      "integrity": "sha512-p63HX3803px30vWrXgog1mRaa3zwABstfb63oSl6DAZ9t/Drc0bCS3FtKDdMKSwY8vLrC8Uytg9hiwQdeKGGKg==",
       "requires": {
         "can-dom-mutate": "^1.0.0",
         "can-fragment": "^1.0.0",
@@ -2859,9 +2778,9 @@
       }
     },
     "can-view-import": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/can-view-import/-/can-view-import-4.2.0.tgz",
-      "integrity": "sha512-xK7cfBW1+nnhpiz7ppXaw53WEJy1Gr+4fCIT8V+LWsjKEt92FymCDJKcGwUGmpotucjLzBdnakkkxwNWPKBOjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/can-view-import/-/can-view-import-4.2.1.tgz",
+      "integrity": "sha512-OKYlJVjfcgboBSmGIlC7R+7srJvS7AnIx5UZBVoFDpuOrQveUkKTz6W5DkyqHUBrLLXEYrowHyxXSuEG5TRRYg==",
       "requires": {
         "can-assign": "^1.0.0",
         "can-child-nodes": "^1.0.0",
@@ -3072,12 +2991,11 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-table": {
@@ -3105,9 +3023,9 @@
       }
     },
     "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-buffer": {
       "version": "1.0.0",
@@ -3144,9 +3062,9 @@
       }
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
     },
     "cloneable-readable": {
       "version": "1.1.2",
@@ -3599,10 +3517,9 @@
       }
     },
     "diff": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-      "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-      "dev": true
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3638,16 +3555,16 @@
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
     },
     "done-autorender": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/done-autorender/-/done-autorender-2.5.5.tgz",
-      "integrity": "sha512-PGO5SD7Kcz9t5DMQLhDuvyV8jNcmKJquVNuQGHMwcFdHsEzxjHfZPlcyag/Qe49HlDv1hzJ7qBKC8GfL9Q7dSQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/done-autorender/-/done-autorender-2.5.6.tgz",
+      "integrity": "sha512-VxXLZegLgJkSOLc4Im9tWGEWKVxbiMWyRYas0k//3mE5RG01rdsvYYHWqhKkCVoh6w6fwzVfyKAQ1sTG5pWpWQ==",
       "requires": {
         "can-dom-mutate": "^1.0.1",
         "can-log": "^1.0.0",
         "can-namespace": "^1.0.0",
         "can-reflect": "^1.11.0",
         "can-route": "^4.0.0",
-        "can-stache": "^4.17.0",
+        "can-stache": "^4.17.3",
         "can-stache-ast": "^1.1.0",
         "can-stache-bindings": "^4.4.0",
         "can-symbol": "^1.5.0",
@@ -3662,9 +3579,9 @@
       },
       "dependencies": {
         "can-stache": {
-          "version": "4.17.2",
-          "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.17.2.tgz",
-          "integrity": "sha512-ewY+KaD/jg1WdzqIdvsb/7Dw9VVAECk1gH92k48lgpkUrBlQp1KeaQKsD6/Q4cC44eoM+2w3Ck9s8Z5yHCl+Pw==",
+          "version": "4.17.3",
+          "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-4.17.3.tgz",
+          "integrity": "sha512-ZY0/tZcSvLDRiZUsMoyz6vS+h/zAB8Ws4VgH/3XTSqY5TEC4PPmAhbeZHgGKwheXNpZn7Rf4hKfuNsoO3Hgs4g==",
           "requires": {
             "can-assign": "^1.1.1",
             "can-attribute-encoder": "^1.0.0",
@@ -3718,9 +3635,9 @@
       }
     },
     "done-mutation": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/done-mutation/-/done-mutation-2.1.6.tgz",
-      "integrity": "sha512-KUR1jXRZmFFlONUIIVK+CY2bHhQqfr3f7RckrVspfzlkKxhJB8VCGXcy+FSXzBXJOQI0V6UH52ymH87Rh/aClg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/done-mutation/-/done-mutation-2.2.0.tgz",
+      "integrity": "sha512-pSu8GCOvixHGhYgw71blmHiI7kF2Gu41noWfeAGlNjaZJ8ww4bgO1xFeEK236L8lbnGe9jkqV8LgIOtRjIfvog==",
       "requires": {
         "utf8": "^3.0.0"
       }
@@ -3796,6 +3713,234 @@
         "mkdirp": "^0.5.1",
         "q": "^1.4.1",
         "yeoman-environment": "^1.2.7"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globby": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+          "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^6.0.1",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "http://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          }
+        }
       }
     },
     "donejs-error-format": {
@@ -3837,11 +3982,11 @@
       }
     },
     "editions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
-      "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+      "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
       "requires": {
-        "errlop": "^1.0.3",
+        "errlop": "^1.1.1",
         "semver": "^5.6.0"
       }
     },
@@ -3970,18 +4115,11 @@
       }
     },
     "errlop": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.0.3.tgz",
-      "integrity": "sha512-5VTnt0yikY4LlQEfCXVSqfE6oLj1HVM4zVSvAKMnoYjL/zrb6nqiLowZS4XlG7xENfyj7lpYWvT+wfSCr6dtlA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
       "requires": {
-        "editions": "^1.3.4"
-      },
-      "dependencies": {
-        "editions": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-        }
+        "editions": "^2.1.2"
       }
     },
     "errno": {
@@ -4347,25 +4485,13 @@
       }
     },
     "external-editor": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "requires": {
-        "extend": "^3.0.0",
-        "spawn-sync": "^1.0.15",
-        "tmp": "^0.0.29"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4503,7 +4629,7 @@
     },
     "feathers-authentication-popups": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-authentication-popups/-/feathers-authentication-popups-0.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/feathers-authentication-popups/-/feathers-authentication-popups-0.1.2.tgz",
       "integrity": "sha1-PfN1V1DwkiZrHs2+yQKZ4b3nSUg=",
       "requires": {
         "debug": "^2.2.0",
@@ -4634,13 +4760,11 @@
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "filename-regex": {
@@ -4708,9 +4832,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.0.tgz",
+      "integrity": "sha512-4Oh4eI3S9OueVV41AgJ1oLjpaJUhbJ7JDGOMhe0AFqoSejl5Q2nn3eGglAzRUKVKZE8jG5MNn66TjCJMAnpsWA==",
       "requires": {
         "debug": "=3.1.0"
       },
@@ -5421,24 +5545,6 @@
         "yeoman-generator": "^2.0.1"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-        },
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -5447,134 +5553,10 @@
             "ms": "^2.1.1"
           }
         },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "globby": {
-          "version": "8.0.1",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.10",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-              "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-              "requires": {
-                "ansi-regex": "^4.0.0"
-              }
-            }
-          }
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "untildify": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
-        },
-        "yeoman-environment": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
-          "integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "cross-spawn": "^6.0.5",
-            "debug": "^3.1.0",
-            "diff": "^3.5.0",
-            "escape-string-regexp": "^1.0.2",
-            "globby": "^8.0.1",
-            "grouped-queue": "^0.3.3",
-            "inquirer": "^6.0.0",
-            "is-scoped": "^1.0.0",
-            "lodash": "^4.17.10",
-            "log-symbols": "^2.2.0",
-            "mem-fs": "^1.1.0",
-            "strip-ansi": "^4.0.0",
-            "text-table": "^0.2.0",
-            "untildify": "^3.0.3"
-          }
         },
         "yeoman-generator": {
           "version": "2.0.5",
@@ -5740,38 +5722,16 @@
       "dev": true
     },
     "globby": {
-      "version": "4.1.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-      "dev": true,
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "requires": {
         "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^6.0.1",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
+        "dir-glob": "^2.0.0",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
       }
     },
     "got": {
@@ -6175,86 +6135,37 @@
       "integrity": "sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0="
     },
     "inquirer": {
-      "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-      "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-      "dev": true,
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^1.1.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rx": "^4.1.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^4.0.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -6920,13 +6831,6 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
       }
     },
     "localtunnel": {
@@ -7193,54 +7097,11 @@
       "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984="
     },
     "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "chalk": "^2.0.1"
       }
     },
     "loose-envify": {
@@ -7371,6 +7232,33 @@
         "through2": "^2.0.0",
         "vinyl": "^1.1.0",
         "vinyl-file": "^2.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
       }
     },
     "mem-fs-editor": {
@@ -7389,49 +7277,6 @@
         "rimraf": "^2.2.8",
         "through2": "^2.0.0",
         "vinyl": "^2.0.1"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        }
       }
     },
     "merge-descriptors": {
@@ -7697,10 +7542,9 @@
       }
     },
     "mute-stream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-      "dev": true
+      "version": "0.0.7",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
       "version": "2.12.1",
@@ -7916,10 +7760,12 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "openurl": {
       "version": "1.1.1",
@@ -8582,9 +8428,9 @@
       }
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.0",
@@ -8645,13 +8491,12 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -9153,9 +8998,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -9345,9 +9190,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -9364,9 +9209,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
       "optional": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -9411,9 +9256,9 @@
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "steal": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/steal/-/steal-2.1.11.tgz",
-      "integrity": "sha512-xP4R7NMHX30RCqU0b89CshrwN7Ywg6ECvw3D6uXEaT+5izh8d6/MhjFCXKrytfB6LULGyCH2pZzwNcbzRgvGkA==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/steal/-/steal-2.1.12.tgz",
+      "integrity": "sha512-odlRyE2kqejCCW0azgdnM8lTvYngY/rfOAronci4Nz2TLVSeBcdpNrPd+PdqRKAa3lpLj2iz5YfY3v5Q4dVfNw==",
       "requires": {
         "assert": "~1.4.1",
         "buffer": "~5.0.4",
@@ -9462,9 +9307,9 @@
       }
     },
     "steal-conditional": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/steal-conditional/-/steal-conditional-1.1.2.tgz",
-      "integrity": "sha512-xEnBG6YtdN0Nv997Bu1AnweRBQTcBcS63eXFSAJzN8YcUaVHlqSpbsMat9n4ScgjWTxmymhDiVdfbX4Z68mfzw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steal-conditional/-/steal-conditional-1.1.3.tgz",
+      "integrity": "sha512-wQ/Rnp+bYUQb4bjHgd0feLrVr5lBSiyvzfcFJTkf0uXxa7Gwheu100tXwRRmUWptl/dufdinZfftNhrI24RTtg==",
       "dev": true
     },
     "steal-config-utils": {
@@ -9638,12 +9483,9 @@
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-bom-stream": {
       "version": "2.0.0",
@@ -9652,6 +9494,16 @@
       "requires": {
         "first-chunk-stream": "^2.0.0",
         "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
       }
     },
     "strip-eof": {
@@ -10340,13 +10192,9 @@
       }
     },
     "untildify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
     },
     "unzip": {
       "version": "0.1.11",
@@ -10522,13 +10370,16 @@
       }
     },
     "vinyl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
-        "replace-ext": "0.0.1"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-file": {
@@ -10544,10 +10395,43 @@
         "vinyl": "^1.1.0"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
         "pify": {
           "version": "2.3.0",
           "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
         }
       }
     },
@@ -10801,64 +10685,53 @@
       "dev": true
     },
     "yeoman-environment": {
-      "version": "1.6.6",
-      "resolved": "http://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
-      "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
-      "dev": true,
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
+      "integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
       "requires": {
-        "chalk": "^1.0.0",
-        "debug": "^2.0.0",
-        "diff": "^2.1.2",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "diff": "^3.5.0",
         "escape-string-regexp": "^1.0.2",
-        "globby": "^4.0.0",
-        "grouped-queue": "^0.3.0",
-        "inquirer": "^1.0.2",
-        "lodash": "^4.11.1",
-        "log-symbols": "^1.0.1",
+        "globby": "^8.0.1",
+        "grouped-queue": "^0.3.3",
+        "inquirer": "^6.0.0",
+        "is-scoped": "^1.0.0",
+        "lodash": "^4.17.10",
+        "log-symbols": "^2.2.0",
         "mem-fs": "^1.1.0",
+        "strip-ansi": "^4.0.0",
         "text-table": "^0.2.0",
-        "untildify": "^2.0.0"
+        "untildify": "^3.0.3"
       },
       "dependencies": {
-        "ansi-regex": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globby": {
+          "version": "8.0.1",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -10894,34 +10767,6 @@
         "yeoman-environment": "^2.0.5"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-        },
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
         "dargs": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.0.0.tgz",
@@ -10933,29 +10778,6 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
           }
         },
         "find-up": {
@@ -10980,36 +10802,6 @@
             "slash": "^1.0.0"
           }
         },
-        "inquirer": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.10",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-              "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-              "requires": {
-                "ansi-regex": "^4.0.0"
-              }
-            }
-          }
-        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -11017,14 +10809,6 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
-          }
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "requires": {
-            "chalk": "^2.0.1"
           }
         },
         "mem-fs-editor": {
@@ -11060,19 +10844,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
         },
         "p-limit": {
           "version": "2.1.0",
@@ -11125,20 +10896,6 @@
             "read-pkg": "^3.0.0"
           }
         },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
         "through2": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
@@ -11146,56 +10903,6 @@
           "requires": {
             "readable-stream": "2 || 3",
             "xtend": "~4.0.1"
-          }
-        },
-        "untildify": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
-        },
-        "vinyl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-          "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-          "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
-          }
-        },
-        "yeoman-environment": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz",
-          "integrity": "sha512-KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "cross-spawn": "^6.0.5",
-            "debug": "^3.1.0",
-            "diff": "^3.5.0",
-            "escape-string-regexp": "^1.0.2",
-            "globby": "^8.0.1",
-            "grouped-queue": "^0.3.3",
-            "inquirer": "^6.0.0",
-            "is-scoped": "^1.0.0",
-            "lodash": "^4.17.10",
-            "log-symbols": "^2.2.0",
-            "mem-fs": "^1.1.0",
-            "strip-ansi": "^4.0.0",
-            "text-table": "^0.2.0",
-            "untildify": "^3.0.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     ]
   },
   "dependencies": {
-    "can": "^5.21.0",
+    "can": "^5.21.2",
     "can-route-pushstate": "^5.0.7",
     "can-stache-route-helpers": "^1.1.3",
     "can-zone": "^1.0.0",
-    "done-autorender": "^2.5.5",
+    "done-autorender": "^2.5.6",
     "done-component": "^2.2.0",
     "done-css": "^3.0.2",
     "done-serve": "^3.0.0",


### PR DESCRIPTION
This upgrades to `done-autorender@2.5.6` and `can@5.21.2`

This fixes the issue with portals used in asynchronously loaded
components.